### PR TITLE
quick workaround for clustername / instancenumber / date elasticache …

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,8 +209,8 @@ func elasticache_maintenance_window(name string, region string) string {
 		initialize_elasticache_connection(region)
 	}
 
-
-	elasticache_name_split_underscore := strings.Split(name, "_")
+        elasticache_name_normalized := strings.Replace(name, "/", "_", -1)
+	elasticache_name_split_underscore := strings.Split(elasticache_name_normalized, "_")
 	elasticache_name_underscore_trimmed := elasticache_name_split_underscore[:len(elasticache_name_split_underscore) - 2]
 	elasticache_name := strings.Join(elasticache_name_underscore_trimmed,"_")
 


### PR DESCRIPTION
…maint window format

Elasticache has an unexpected second maintenance window format which differs from the standard 

<cluster>_<id>_<region>

the second format is

"cluster-name / cluster-name-instance / <datetime>"

which does not contain the info we're looking for. This fix is purely to unbreak the utility. There is no expectation that these elasticache events are properly handled and this needs further investigation as time and people permit.

